### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: ruby
 rvm:
-  - 2.3.0
-  - 2.0.0
   - 1.9.3
+  - 2.0.0
+  - 2.1.9
+  - 2.2.6
+  - 2.3.3
+  - 2.4.2
 
 before_install:
  - gem install ruby-debug-ide

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ rvm:
   - 2.4.2
 
 before_install:
- - gem install ruby-debug-ide
- - nvm install v6.9.1
- - nvm use v6.9.1
+  - gem install ruby-debug-ide
+  - nvm install 8.9.3
+  - echo "8.9.3" > .nvmrc
+
 before_script:
+  - nvm use
   - npm install -g typescript -v 2.1.5
   - npm install
-  - tsc -p ./src
-script: npm run test-debugger
+  - npm run compile
+script: nvm use && npm run test-debugger

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.9
-  - 2.2.6
-  - 2.3.3
-  - 2.4.2
+  - 2.1.10
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
 
 before_install:
   - gem install ruby-debug-ide

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,3 +27,5 @@ environment:
     - ruby_version: "22-x64"
     - ruby_version: "23"
     - ruby_version: "23-x64"
+    - ruby_version: "24"
+    - ruby_version: "24-x64"

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,11 @@
 # Ruby Language and Debugging Support for Visual Studio Code
 
-[![Join the chat at https://rubyide-slackin.azurewebsites.net](./images/badge.png)](https://rubyide-slackin.azurewebsites.net) [![Build Status](https://api.travis-ci.org/rubyide/vscode-ruby.svg?branch=master)](https://travis-ci.org/rubyide/vscode-ruby) [![Build status](https://ci.appveyor.com/api/projects/status/vlgs2y7tsc4xpj4c?svg=true)](https://ci.appveyor.com/project/rebornix/vscode-ruby)
+[![Join the chat at https://rubyide-slackin.azurewebsites.net](./images/badge.png)](https://rubyide-slackin.azurewebsites.net)
+[![Build Status](https://travis-ci.org/wingrunr21/vscode-ruby-lang.svg?branch=master)](https://travis-ci.org/wingrunr21/vscode-ruby-lang)
+[![Build status](https://ci.appveyor.com/api/projects/status/satow2kjho27kph6?svg=true)](https://ci.appveyor.com/project/wingrunr21/vscode-ruby-lang)
 
-This extension provides rich Ruby language and debugging support for VS Code. It's still in progress ( [GitHub](https://github.com/rubyide/vscode-ruby.git) ), please expect frequent updates with breaking changes before 1.0. 
+
+This extension provides rich Ruby language and debugging support for VS Code. It's still in progress ( [GitHub](https://github.com/rubyide/vscode-ruby.git) ), please expect frequent updates with breaking changes before 1.0.
 
 It started as a personal project of [@rebornix](https://github.com/rebornix), aiming to bring Ruby debugging experience to VS Code. Then it turned to be a community driven project. With his amazing commits, [@HookyQR](https://github.com/HookyQR) joined as a contributor and brought users Linting/Formatting/etc, made the debugger more robust and more! If you are interested in this project, feel free to join the [community](https://github.com/rubyide/vscode-ruby/graphs/contributors):  file [issues](https://github.com/rubyide/vscode-ruby/issues/new), fork [our project](https://github.com/rubyide/vscode-ruby) and hack it around and send us PRs, or subscribe to our [mailing list](http://eepurl.com/bTBAfv).
 


### PR DESCRIPTION
Update `appveyor.yml` and `.travis.yml` for current Ruby versions. Note that appveyor does not yet support Ruby 2.5