### PR TITLE
Fix highlighting

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -15,7 +15,7 @@ export function activate(context: ExtensionContext) {
 	// register language config
 	vscode.languages.setLanguageConfiguration('ruby', {
 		indentationRules: {
-			increaseIndentPattern: /^\s*((begin|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while)|(.*\sdo\b))\b[^\{;]*$/,
+			increaseIndentPattern: /^\s*((begin|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while)|(.*\sdo\b))\b[^;]*$/,
 			decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif|when)\b)/
 		},
 		wordPattern: /(-?\d+(?:\.\d+))|(:?[A-Za-z][^-`~@#%^&()=+[{}|;:'",<>/.*\]\s\\!?]*[!?]?)/
@@ -52,7 +52,7 @@ function registerHighlightProvider(ctx: ExtensionContext) {
 	}
 
 	const getEntry = function(line) {
-		let match = line.text.match(/^(.*\b)(begin|class|def|for|if|module|unless|until|case|while)\b[^\;]*$/);
+		let match = line.text.match(/^(.*\b)(begin|class|def|for|if|module|unless|until|case|while)\b[^;]*$/);
 		if (match) {
 			return new vscode.Range(line.lineNumber, match[1].length, line.lineNumber, match[1].length + match[2].length);
 		} else {

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -52,8 +52,7 @@ function registerHighlightProvider(ctx: ExtensionContext) {
 	}
 
 	const getEntry = function(line) {
-		//only lines that start with the entry
-		let match = line.text.match(/^(\s*)(begin|class|def|for|if|module|unless|until|case|while)\b[^\{;]*$/);
+		let match = line.text.match(/^(.*\b)(begin|class|def|for|if|module|unless|until|case|while)\b[^\;]*$/);
 		if (match) {
 			return new vscode.Range(line.lineNumber, match[1].length, line.lineNumber, match[1].length + match[2].length);
 		} else {


### PR DESCRIPTION
This updates the entry regex to handle the uses cases outlined in rubyide/vscode-ruby#234. The first commit addresses the highlighting issues. The original regex did not correctly match on patterns like `def foo(params = {})` or `bar = if ...`.

This fixes rubyide/vscode-ruby#234.

- [x] Build pass!
- [x] Follow VS Code [Coding Guidelines](https://github.com/Microsoft/vscode/wiki/Coding-Guidelines)